### PR TITLE
added an API for logging

### DIFF
--- a/src/main/java/APIFactoryReceiver.java
+++ b/src/main/java/APIFactoryReceiver.java
@@ -1,5 +1,5 @@
 package io.spicelabs.rodeocomponents;
 
 public interface APIFactoryReceiver {
-  public <T extends API> void publishFactory(RodeoComponent publisher, String apiName, APIFactory<T> apiFactory);
+  public <T extends API> void  publishFactory(RodeoComponent publisher, String apiName, APIFactory<T> apiFactory, Class<T> apiType);
 }

--- a/src/main/java/APIFactorySource.java
+++ b/src/main/java/APIFactorySource.java
@@ -3,5 +3,5 @@ package io.spicelabs.rodeocomponents;
 import java.util.Optional;
 
 public interface APIFactorySource {
-    public <T extends API> Optional<APIFactory<T>> getAPIFactory(String name, RodeoComponent subscriber);
+    public <T extends API> Optional<APIFactory<T>> getAPIFactory(String name, RodeoComponent subscriber, Class<T> factoryType);
 }

--- a/src/main/java/APIS/RodeoLogger.java
+++ b/src/main/java/APIS/RodeoLogger.java
@@ -1,0 +1,10 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+import io.spicelabs.rodeocomponents.API;
+public interface RodeoLogger extends API {
+  void error(String message);
+  void error(String message, Throwable cause);
+  void warn(String message);
+  void info(String message);
+  void debug(String message);
+}

--- a/src/main/java/APIS/RodeoLoggerConstants.java
+++ b/src/main/java/APIS/RodeoLoggerConstants.java
@@ -1,0 +1,5 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+public class RodeoLoggerConstants {
+  public static final String NAME = "RodeoLogger";
+}

--- a/src/main/java/RodeoEnvironment.java
+++ b/src/main/java/RodeoEnvironment.java
@@ -1,0 +1,10 @@
+package io.spicelabs.rodeocomponents;
+import java.lang.Runtime.Version;
+
+public class RodeoEnvironment {
+
+    private static final Version _currentVersion = Version.parse("1.0.0.1");;
+    public static Version currentVersion() {
+        return _currentVersion;
+    }
+}

--- a/src/test/resources/META-INF/services/io.spicelabs.rodeocomponents.RodeoComponent
+++ b/src/test/resources/META-INF/services/io.spicelabs.rodeocomponents.RodeoComponent
@@ -1,1 +1,4 @@
 io.spicelabs.components.testing.MockComponent
+io.spicelabs.components.testing.GoodClass
+io.spicelabs.components.testing.BadVersionClass
+io.spicelabs.components.testing.LoggingClass

--- a/src/test/scala/LoadingTests.scala
+++ b/src/test/scala/LoadingTests.scala
@@ -1,0 +1,26 @@
+package io.spicelabs.components.testing
+
+import io.spicelabs.rodeocomponents.*
+
+import java.lang.Runtime.Version
+import java.util.ServiceLoader
+
+
+class GoodClass extends MockComponent {
+    override def getIdentity(): RodeoIdentity = MockIdentity("loadingtest-good")
+    override def getComponentVersion(): Version = RodeoEnvironment.currentVersion()
+}
+
+class BadVersionClass extends MockComponent {
+    override def getIdentity(): RodeoIdentity = MockIdentity("loadingtest-bad-version")
+    override def getComponentVersion(): Version = Version.parse("800.0.0.1")
+}
+
+class LoadingTests extends munit.FunSuite {
+    test("good-and-bad") {
+        val loader = MockLoader("loadingtest.*")
+        loader.loadComponents()
+        assertEquals(loader.badComponents.length, 1)
+        assertEquals(loader.components.length, 1)
+    }
+}

--- a/src/test/scala/LoggingTest.scala
+++ b/src/test/scala/LoggingTest.scala
@@ -1,0 +1,91 @@
+package io.spicelabs.components.testing
+
+import io.spicelabs.rodeocomponents.*
+
+import java.lang.Runtime.Version
+import java.util.ServiceLoader
+import io.spicelabs.rodeocomponents.APIS.RodeoLogger
+
+class MockLogger(report: (String, String) => Unit) extends RodeoLogger {
+    override def debug(message: String): Unit = {
+        report("debug", message)
+    }
+    override def error(message: String): Unit = {
+        report("error", message)
+    }
+    override def error(message: String, cause: Throwable): Unit = {
+        report("error", message)
+    }
+    override def info(message: String): Unit = {
+        report("info", message)
+    }
+    override def warn(message: String): Unit = {
+        report("warn", message)
+    }
+    override def release(): Unit = { }
+}
+
+class MockLoggerFactory(ml: MockLogger) extends APIFactory[RodeoLogger] {
+    override def name(): String = "MockLogger"
+    override def buildAPI(): RodeoLogger = ml
+}
+
+class LoggingClass extends MockComponent {
+    var lastLevel = ""
+    var lastMessage = ""
+    val logger = MockLogger((level, message) => {
+        lastLevel = level
+        lastMessage = message
+    })
+    override def getIdentity(): RodeoIdentity = MockIdentity("logging-test")
+    override def getComponentVersion(): Version = RodeoEnvironment.currentVersion()
+    override def exportAPIFactories(receiver: APIFactoryReceiver): Unit = {
+        receiver.publishFactory(this, "MockLogger", MockLoggerFactory(logger), classOf[RodeoLogger])
+    }
+}
+
+
+class LoggingTest  extends munit.FunSuite {
+    test("loads-logger") {
+        val loader = MockLoader("logging\\-test")
+        loader.loadComponents()
+        assertEquals(loader.badComponents.length, 0)
+        assertEquals(loader.components.length, 1)       
+    }
+
+    test("published-api") {
+        val loader = MockLoader("logging\\-test")
+        loader.loadComponents()
+        loader.componentPublishAPIFactories()
+        assertEquals(loader.exportedAPIs.size, 1)
+        assert(loader.exportedAPIs.contains("MockLogger"))
+    }
+
+    test("api-works") {
+        val loader = MockLoader("logging\\-test")
+        loader.loadComponents()
+        loader.componentPublishAPIFactories()
+
+        val loggerComponent = loader.components(0).asInstanceOf[LoggingClass]
+
+        val loggerFactoryOpt = loader.getAPIFactory[RodeoLogger]("MockLogger", null, classOf[RodeoLogger])
+        val loggerFactory = loggerFactoryOpt.get()
+        val logger = loggerFactory.buildAPI()
+
+        logger.debug("foo")
+        assertEquals(loggerComponent.lastLevel, "debug")
+        assertEquals(loggerComponent.lastMessage, "foo")
+
+        logger.error("bar")
+        assertEquals(loggerComponent.lastLevel, "error")
+        assertEquals(loggerComponent.lastMessage, "bar")
+
+        logger.warn("baz")
+        assertEquals(loggerComponent.lastLevel, "warn")
+        assertEquals(loggerComponent.lastMessage, "baz")
+
+        logger.info("splunge")
+        assertEquals(loggerComponent.lastLevel, "info")
+        assertEquals(loggerComponent.lastMessage, "splunge")
+    }
+}

--- a/src/test/scala/MockLoader.scala
+++ b/src/test/scala/MockLoader.scala
@@ -1,0 +1,96 @@
+package io.spicelabs.components.testing
+
+import io.spicelabs.rodeocomponents.RodeoComponent
+import java.util.ServiceLoader
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
+import io.spicelabs.rodeocomponents.RodeoEnvironment
+import io.spicelabs.rodeocomponents.APIFactoryReceiver
+import io.spicelabs.rodeocomponents.APIFactorySource
+import io.spicelabs.rodeocomponents.APIFactory
+import io.spicelabs.rodeocomponents.API
+import java.{util => ju}
+import scala.collection.mutable.HashMap
+
+private case class PublishedAPIFactory[T <: API](component: RodeoComponent, apiFactory: APIFactory[T], factoryType: Class[T])
+
+class MockLoader(identityPattern: String) extends APIFactoryReceiver, APIFactorySource {
+    val componentMatcher = identityPattern.r
+    val components: ArrayBuffer[RodeoComponent] = ArrayBuffer()
+    val badComponents: ArrayBuffer[RodeoComponent] = ArrayBuffer()
+
+    val exportedAPIs: HashMap[String, PublishedAPIFactory[?]] = HashMap()
+
+    def loadComponents() = {
+        val loader = ServiceLoader.load(classOf[RodeoComponent])
+        var members = List[RodeoComponent]()
+        for el <- loader.iterator().asScala do {
+            try {
+                el.initialize()
+                if (regexMatches(el)) {
+                    if (elementIsValid(el)) {
+                        components.addOne(el)
+                    } else {
+                        badComponents.addOne(el)
+                    }
+                }
+            } catch {
+                case err: Exception => {
+                    val message = err.getMessage()
+                    ()
+                }
+            }
+        }
+    }
+
+    def componentPublishAPIFactories() = {
+        for comp <- components do {
+            try {
+                comp.exportAPIFactories(this)
+            } catch {
+                case err: Exception => ()
+            }
+        }
+    }
+
+    def componentImportAPIFactories() = {
+        for comp <- components do {
+            try {
+                comp.importAPIFactories(this)
+            } catch {
+                case err: Exception => ()
+            }
+        }
+    }
+
+    private def regexMatches(el: RodeoComponent): Boolean = {
+        val identity = el.getIdentity()
+        if (identity == null)
+            return false
+        componentMatcher.matches(identity.name())
+    }
+  
+    private def elementIsValid(el: RodeoComponent): Boolean = {
+        if (el.getComponentVersion() != RodeoEnvironment.currentVersion())
+            return false
+        return true    
+    }
+
+    override def publishFactory[T <: API](publisher: RodeoComponent, apiName: String, apiFactory: APIFactory[T], apiType: Class[T]): Unit = {
+        exportedAPIs += (apiName -> PublishedAPIFactory(publisher, apiFactory, apiType))
+    }
+
+    override def getAPIFactory[T <: API](name: String, subscriber: RodeoComponent, factoryType: Class[T]): ju.Optional[APIFactory[T]] = {
+        val factoryOpt = exportedAPIs.get(name)
+
+        factoryOpt match
+            case Some(factory) => {
+                if (factory.factoryType != factoryType)
+                    ju.Optional.empty()
+                else
+                    ju.Optional.of(factory.apiFactory.asInstanceOf[APIFactory[T]])
+            }
+            case None => ju.Optional.empty()
+    }
+
+}


### PR DESCRIPTION
This PR shows the general functioning of the component API model.

I added an API named `RodeoLogger` which encompasses the logging facilities that we'll have.

To test this (and the general process), I made a MockLoader class which loads components which match a given regular expression. This class does some very simple checking to see that the component is valid, which in this case amounts to the version that the component reports is the same as the component model version.

MockLoader filters components into two bins that are inspectable (in reality they shouldn't be).

I created a MockLogger which implements the RodeoLogger API (but not the actual name). The MockLogger is constructed with a function to report what logging has happened so we can test it.

I created a MockLoggerFactory which just uses a singleton of the MockLogger.

Then the actual tests test:
1. is the LoggerComponent loaded
2. does the LoggerComponent publish an API factory named "MockLogger"
3. is the API factory published by LoggerComponent accessible
4. is the resulting API functional