### PR TITLE
test publishing and importing by components

### DIFF
--- a/src/test/resources/META-INF/services/io.spicelabs.rodeocomponents.RodeoComponent
+++ b/src/test/resources/META-INF/services/io.spicelabs.rodeocomponents.RodeoComponent
@@ -2,3 +2,4 @@ io.spicelabs.components.testing.MockComponent
 io.spicelabs.components.testing.GoodClass
 io.spicelabs.components.testing.BadVersionClass
 io.spicelabs.components.testing.LoggingClass
+io.spicelabs.components.testing.FooReporterComponent

--- a/src/test/scala/PublishingTests.scala
+++ b/src/test/scala/PublishingTests.scala
@@ -1,0 +1,95 @@
+package io.spicelabs.components.testing
+
+import io.spicelabs.rodeocomponents.APIFactory
+import io.spicelabs.rodeocomponents.API
+import io.spicelabs.rodeocomponents.APIFactoryReceiver
+import io.spicelabs.rodeocomponents.RodeoIdentity
+import java.lang.Runtime.Version
+import io.spicelabs.rodeocomponents.RodeoEnvironment
+import scala.compiletime.ops.double
+import io.spicelabs.rodeocomponents.APIFactorySource
+import scala.jdk.OptionConverters._
+
+trait Reporter extends API {
+    def report(message: String): Unit
+}
+
+class FooReporter(reportFunc: (String) => Unit) extends Reporter {
+    override def report(message: String): Unit = {
+        reportFunc(message)
+    }
+    override def release(): Unit = { }
+}
+
+class FooReporterFactory(fr: FooReporter) extends APIFactory[Reporter] {
+    override def name(): String = "foo-reporter"
+    override def buildAPI(): Reporter = fr
+}
+
+trait Worker extends API {
+    def work(): Unit
+}
+
+class FooWorker extends Worker {
+    var reporter: Option[Reporter] = None
+    override def work() = {
+        reporter.foreach(r => r.report(("did it")))
+    }
+    override def release(): Unit = { }
+}
+
+class FooWorkerFactory(fw: FooWorker) extends APIFactory[Worker] {
+    override def name(): String = "foo-worker"
+    override def buildAPI(): Worker = fw
+}
+
+class FooReporterComponent extends MockComponent {
+    var lastReport = ""
+    val reporter = FooReporter((s) => {
+        lastReport = s
+    })
+
+    val worker = FooWorker()
+
+    override def getIdentity(): RodeoIdentity = MockIdentity("publishing-test")
+    override def getComponentVersion(): Version = RodeoEnvironment.currentVersion()
+    override def exportAPIFactories(receiver: APIFactoryReceiver): Unit = {
+        receiver.publishFactory(this, "Reporter", FooReporterFactory(reporter), classOf[Reporter])
+        receiver.publishFactory(this, "Worker", FooWorkerFactory(worker), classOf[Worker])
+    }
+
+    override def importAPIFactories(factorySource: APIFactorySource): Unit = {
+        val reporterFactory = factorySource.getAPIFactory[Reporter]("Reporter", this, classOf[Reporter]).toScala
+        if (reporterFactory.isDefined) {
+            worker.reporter = Some(reporterFactory.get.buildAPI())
+        }
+    }
+}
+
+class PublishingTests extends munit.FunSuite {
+    test("loads-publisher") {
+        val loader = MockLoader("publishing\\-test")
+        loader.loadComponents()
+        assertEquals(loader.badComponents.length, 0)
+        assertEquals(loader.components.length, 1)       
+    }
+
+    test("publish-import") {
+        val loader = MockLoader("publishing\\-test")
+        loader.loadComponents()
+        loader.componentPublishAPIFactories()
+        loader.componentImportAPIFactories()
+
+
+        val fooReporterComponent = loader.components(0).asInstanceOf[FooReporterComponent]
+
+        val workerFactoryOpt = loader.getAPIFactory[Worker]("Worker", null, classOf[Worker])
+        val workerFactory = workerFactoryOpt.get()
+        val localWorker = workerFactory.buildAPI()
+
+        localWorker.work()
+
+        assertEquals(fooReporterComponent.lastReport, "did it")
+
+    }
+}


### PR DESCRIPTION
This PR adds a test to ensure that components can publish and import APIs. In this case the test publishes two APIs:
- Reporter - provides an API to report information
- Worker - provides an API to perform some work and reports that work

The process of loading components involves the following steps in order:
- initialization
- publish API factories
- subscribe to API factories

The  test runs through these steps, then acquires the worker API and invokes it, ensuring that the reporter has been called.

Why is this test important?
It shows a strength and a weakness in the design. The strength is that components can export arbitrary APIs that are easy to access in a way that is type-strong. The weakness is that there is that the design tends to encourage unusual dependencies that need some care.

For example:
API Alpha knows of the existence of API Beta and requires it to operate, but at the time that it is published, it doesn't know if Beta was successfully loaded until it is called to import Beta. It is possible that the factory for API Alpha has been acquired by another component, but the actual API might not be functional.

In addition, the lazy aspect of this means that components will necessitate side-effect laced code like you see in the worker which has its reporter set later.

I don't think this is a show-stopper, though.
