### PR TITLE
added Component writing how-to

### DIFF
--- a/doc/authoring.md
+++ b/doc/authoring.md
@@ -1,0 +1,173 @@
+# Authoring a Component
+
+The main interfacing for the Goat Rodeo Component Model is written in Java, so any JVM language that can implement Java interfaces and consume implementations of Java interfaces can be used to create a Component. 
+
+In order for your component to be visible to Goat Rodeo, you must do the following:
+
+- Create a reference in your project to RodeoComponents **TODO - add a link to the maven repository**
+- Create one or more classes that implement the interface `RodeoComponent`
+- Advertise your components in your resources (see below)
+- Compile and package your code into a JAR file
+
+
+## Implementing RodeoComponent
+
+First create a public class that extends `RodeoComponent`
+
+```java
+package com.yourcompany.components;
+import io.spicelabs.rodeocomponents.*;
+import java.lang.Runtime.Version;
+
+public class MyComponent extends RodeoComponent {
+  public MyComponent() { }
+  public void initialize() throws Exception { }
+  public RodeoIdentity getIdentity() { /* TODO */ }
+  public Version getComponentVersion() { /* TODO */ }
+  public void exportAPIFactories(APIFactoryReceiver receiver) { }
+  public void importAPIFactories(APIFactorySource factorySource) { }
+  public void onLoadingComplete() { }
+  public void shutDown() { }
+}
+```
+
+Next stub out the methods. For `getIdentity`, you will need a class that implements `RodeoIdentity`. You can create a separate class that implements this if you want. Sometimes for build automation this is easier, but for expedience, you can simply implement `RodeoIdentity` in the same class that implements `RodeoComponent`
+
+```java
+package com.yourcompany.components;
+import io.spicelabs.rodeocomponents.*;
+import java.lang.Runtime.Version;
+
+// simple implementation of a component
+
+public class MyComponent extends RodeoComponent, RodeoIdentity {
+  private static final _name = "MyComponent"
+  private static final _publisher = "YourCompany"
+  public MyComponent() { }
+  
+  public void initialize() throws Exception { }
+
+  // RodeoIdentity implementation
+  public String name() { return _name; }
+  public String publisher() { return _publisher; }
+
+  public RodeoIdentity getIdentity() { return this; }
+  public Version getComponentVersion() { return RodeoEnvironment.currentVersion(); }
+  public void exportAPIFactories(APIFactoryReceiver receiver) { }
+  public void importAPIFactories(APIFactorySource factorySource) { }
+  public void onLoadingComplete() { }
+  public void shutDown() { }
+}
+```
+
+Finally, you need to create a file in your `resources` directory in the subdirectory `META-INF/services` named `io.spicelabs.rodeocomponents.RodeoComponent`. This is a text file that is a list of all types that implement `RodeoComponent`. Each line should be the fully qualified name of your component:
+```
+com.yourcompany.components.MyComponent
+```
+
+
+## Importing APIs From Your Component
+
+In order to do anything useful as a Component of Goat Rodeo, you will need to do some work in `importAPIFactories`. For each API you want to import, you will need to call the `factorySource` method `getAPIFactory`. This method takes the name of the API you want to import, an instance of the `RodeoComponent` importing the factory, and the expected type of the API. After importing the factory, the Component will need to call the factory to get the actual API.
+
+Each API should have a class that defines the name of the API that should be passed to `factorySource`.
+
+Here's an example of how to do that:
+
+```java
+public class MyComponent extends RodeoComponent, RodeoIdentity {
+ 
+  APIFactory<RodeoLogger> loggerFactory;
+  RodeoLogger logger;
+
+  public void importAPIFactories(APIFactorySource factorySource) {
+    Optional<APIFactory<RodeoLogger>> opt = factorySource.getAPIFactory(
+          RodeoLoggerConstants.NAME, this, APIFactory<RodeoLogger>.class);
+    if (!opt.isPresent())
+        return;
+    loggerFactory = opt.get();
+    logger = loggerFactory.buildAPI();
+  }
+
+  public void onLoadingComplete() {
+    logger.info("MyComponent has been loaded.")
+  }
+}
+```
+
+## Exporting Your Own APIs
+
+To export an API from your component, you will need to do several things:
+
+1. Define an interface for your API
+2. Define a constant name for your API
+3. Publish your API in its own JAR*
+4. Write a class that implements your API
+5. Write a class that implements `APIFactory` specialized to your API type
+6. When your Component's `exportAPIFactories` method is called, call the receiver with your `APIFactory`
+
+*This is not strictly necessary, but if you want other Components to have access to your API's, it's cleaner to have the your Component and other Components depend on the same JAR instead of requiring other Components to depend on your Component's JAR.
+
+### Defining an Interface For Your API
+
+This is done by creating a Java interface that exposes the functionality that you want and implements the interface `API`. Here is an example of how to do that:
+
+```java
+public interface MyGreeter extends API { // define the interface
+  void greet();
+}
+
+public class MyGreeterConstants { // define the name
+  public static final NAME = "MyComponentGreeter";
+}
+```
+
+### Implementing Your API
+
+This is as simple as creating a class that implements your interface:
+
+```java
+public class MyGreeterImpl extends MyGreeter {
+  private String _owner;
+  public MyGreeterImpl(String owner) {
+    _owner = owner;
+  }
+  public void greet() {
+    System.out.println("Greetings from " + _owner + "!");
+  }
+
+  public void release() { }
+}
+```
+
+### Implementing Your Factory
+
+To write your factory, you need to create a class that implements the `APIFactory<T>` where T is your API *interface*:
+
+```java
+public class MyGreeterFactory extends APIFactory<MyGreeter> {
+  public MyGreeterFactory() { }
+  public String name() { return MyGreeterConstants.NAME; }
+  public MyGreeter buildAPI(RodeoComponent subscriber) {
+    return new MyGreeterImpl(subscriber.getIdentity().name());
+  }
+}
+```
+
+Note how that API factory is able to customize the API to the subscriber. This is not mandatory, but can be useful to track which Components are using your API.
+
+### Publishing Your API Factory
+
+When your Component has its `exportAPIFactories` method called, your component can expose it's API factory by calling the `publishFactory` method for each API factory that it exports.
+
+Here is a simple example that demonstrates that:
+
+```java
+public class MyComponent extends RodeoComponent {
+  public void exportAPIFactories(APIFactory receiver) {
+    MyGreeterFactory factory = MyGreeterFactory();
+    // Note: the class that gets passed in is the class of the API interface NOT the factory
+    receiver.publishFactory(this, factory.name(), factory, MyGreeter.class);
+  }
+}
+```

--- a/src/main/java/APIFactory.java
+++ b/src/main/java/APIFactory.java
@@ -2,5 +2,5 @@ package io.spicelabs.rodeocomponents;
 
 public interface APIFactory<T extends API> {
     String name();
-    T buildAPI();
+    T buildAPI(RodeoComponent subscriber);
 }

--- a/src/main/java/RodeoComponentv0.java
+++ b/src/main/java/RodeoComponentv0.java
@@ -2,7 +2,7 @@ package io.spicelabs.rodeocomponents;
 import java.lang.Runtime.Version;
 
 public interface RodeoComponentv0 {
-  void initialize();
+  void initialize() throws Exception;
   RodeoIdentity getIdentity();
   Version getComponentVersion();
   void exportAPIFactories(APIFactoryReceiver receiver);

--- a/src/test/scala/LoggingTest.scala
+++ b/src/test/scala/LoggingTest.scala
@@ -27,7 +27,7 @@ class MockLogger(report: (String, String) => Unit) extends RodeoLogger {
 
 class MockLoggerFactory(ml: MockLogger) extends APIFactory[RodeoLogger] {
     override def name(): String = "MockLogger"
-    override def buildAPI(): RodeoLogger = ml
+    override def buildAPI(subscriber: RodeoComponent): RodeoLogger = ml
 }
 
 class LoggingClass extends MockComponent {
@@ -70,7 +70,7 @@ class LoggingTest  extends munit.FunSuite {
 
         val loggerFactoryOpt = loader.getAPIFactory[RodeoLogger]("MockLogger", null, classOf[RodeoLogger])
         val loggerFactory = loggerFactoryOpt.get()
-        val logger = loggerFactory.buildAPI()
+        val logger = loggerFactory.buildAPI(loggerComponent)
 
         logger.debug("foo")
         assertEquals(loggerComponent.lastLevel, "debug")


### PR DESCRIPTION
Lots of text to describe how to write a component.

In doing so, I noted a couple of things that needed some attention.

In the docs, I made it clear that if initialize fails, it should throw an exception, but I forgot that Java requires you to declare what you might throw or fail to catch, so I changed the declaration.

I noticed that there was no way for the API factory to have access to the component that was subscribing to the API, so I added that in as an argument to the  buildAPI method. 