### PR TITLE
Adding an API for handling command line arguments

### DIFF
--- a/src/main/java/APIS/RodeoArgumentConstants.java
+++ b/src/main/java/APIS/RodeoArgumentConstants.java
@@ -1,0 +1,5 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+public class RodeoArgumentConstants {
+  public final static String NAME = "ArgumentRegistrar";
+}

--- a/src/main/java/APIS/RodeoArgumentListener.java
+++ b/src/main/java/APIS/RodeoArgumentListener.java
@@ -1,0 +1,9 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+import java.util.List;
+
+public interface RodeoArgumentListener {
+  RodeoArgumentMemento begin();
+  RodeoArgumentResult receiveArgument(List<String> parameters, RodeoArgumentMemento memento);
+  RodeoArgumentResult end(RodeoArgumentMemento memento);
+}

--- a/src/main/java/APIS/RodeoArgumentMemento.java
+++ b/src/main/java/APIS/RodeoArgumentMemento.java
@@ -1,0 +1,3 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+public interface RodeoArgumentMemento { }

--- a/src/main/java/APIS/RodeoArgumentRegistrar.java
+++ b/src/main/java/APIS/RodeoArgumentRegistrar.java
@@ -1,0 +1,7 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+import io.spicelabs.rodeocomponents.API;
+
+public interface RodeoArgumentRegistrar extends API {
+    void register(RodeoArgumentListener listener);
+}

--- a/src/main/java/APIS/RodeoArgumentResult.java
+++ b/src/main/java/APIS/RodeoArgumentResult.java
@@ -1,0 +1,31 @@
+package io.spicelabs.rodeocomponents.APIS;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class RodeoArgumentResult {
+    private final Optional<RodeoArgumentMemento> _memento;
+    private final Optional<String> _error;
+
+    private RodeoArgumentResult(Optional<RodeoArgumentMemento> memento, Optional<String> error) {
+        _memento = memento;
+        _error = error;
+    }
+    public Optional<RodeoArgumentMemento> getMemento() {
+        return _memento;
+    }
+
+    public Optional<String> getError() {
+        return _error;
+    }
+  
+    public static RodeoArgumentResult fromMemento(RodeoArgumentMemento memento) {
+        Objects.requireNonNull(memento, "memento");
+        return new RodeoArgumentResult(Optional.of(memento), Optional.empty());
+    }
+
+    public static RodeoArgumentResult fromError(String error) {
+        Objects.requireNonNull(error, "error");
+        return new RodeoArgumentResult(Optional.empty(), Optional.of(error));
+    }
+}


### PR DESCRIPTION
This is a cut for the command line argument handling.  The idea is going to be like this (hopefully):
- arguments will be passed to components in the form `--component <component-name> argument+`
- the existing parser will aggregate all of the arguments first
- components can register an argument listener
- after loading is complete, we'll loop through the aggregated component arguments and track which ones get used, which ones have no listeners, and which generate errors, then spew the errors (if any)

An argument listener is an object which responds to 3 method invocations:
- `begin()` an opportunity to initialize argument processing and return a memento
- `receiveArgument()` for which the argument comes in with a list of parameters and the memento returned from `begin`, the listener will return a `RodeoArgumentResult` which is a fake discriminated union of either a (possibly new) memento or an error
- `end` will be called with the last memento that we got and the component will return another DU

Why this is done this way:
- It allows components to handle their arguments the way that they want
- The memento pattern is built in a way that can encourage state passed with fewer side effects (eg, more functional), but it doesn't forbid the more traditional OO approach to state
- It allows error detection during argument processing or at the end or both
- It doesn't demand or forbid duplicate parameters (eg, `--component foo verbose --component foo verbose`)
- Components should receive arguments in the order in which they were presented so positional and non-positional arguments are possible
- It doesn't dictate parameter formatting other than they shouldn't start with a `-` for obvious reasons.
- There is a single end-point in the API to register a listener. Keep It Simple Steve.
- Since the API will get built from the API factory, we will implicitly know the name of the component, which will also let us point out when parameters came in for a component that didn't register a listener.