### PR TITLE
Definitions for artifact handlers

### DIFF
--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/Artifact.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/Artifact.java
@@ -1,0 +1,21 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public interface Artifact {
+    String path();
+    long size();
+    String mimeType();
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactConstants.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactConstants.java
@@ -1,0 +1,19 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+class ArtifactConstants {
+    public static final String NAME = "ArtifactHandlerRegistrar";
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandler.java
@@ -1,0 +1,33 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import io.spicelabs.rodeocomponents.APIS.purls.Purl;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+
+public interface ArtifactHandler<T extends InputStream> {
+  Optional<String> identifyMimeType(T stream, String mimeSoFar);
+  Optional<String> finalMimeAdjustment(T stream, String mimeSoFar);
+
+  boolean willHandleMime(String mime);
+
+  ArtifactMemento begin(T stream, Artifact artifact, WorkItem item);
+  List<Purl> getPurls(ArtifactMemento memento, Artifact artifact, WorkItem item);
+  List<Metadata> getMetadata(ArtifactMemento memento, Artifact artifact, WorkItem item);
+  void augment(ArtifactMemento memento, Artifact artifact, WorkItem item, ParentFrame parent, BackendStorage storage);
+  void postChildProcessing(ArtifactMemento memento, Optional<List<String>> gitoids, BackendStorage storage);
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandlerRegistrar.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandlerRegistrar.java
@@ -1,0 +1,22 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import io.spicelabs.rodeocomponents.API;
+
+public interface ArtifactHandlerRegistrar extends API {
+    void register(FileArtifactHandler handler);
+    void register(InputStreamArtifactHandler handler);
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactMemento.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactMemento.java
@@ -1,0 +1,17 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public interface ArtifactMemento { }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/BackendStorage.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/BackendStorage.java
@@ -1,0 +1,25 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import io.spicelabs.rodeocomponents.APIS.purls.Purl;
+import java.util.Set;
+
+public interface BackendStorage {
+    void addPurl(Purl purl);
+    Set<String> purls();
+    Set<String> keys();
+    boolean contains(String identifier);
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/FileArtifactHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/FileArtifactHandler.java
@@ -1,0 +1,21 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import java.io.FileInputStream;
+
+public interface FileArtifactHandler extends ArtifactHandler<FileInputStream> {
+  
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/InputStreamArtifactHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/InputStreamArtifactHandler.java
@@ -1,0 +1,21 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import java.io.InputStream;
+
+public interface InputStreamArtifactHandler extends ArtifactHandler<InputStream> {
+  
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/Metadata.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/Metadata.java
@@ -1,0 +1,31 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public class Metadata {
+    private final MetadataTag _tag;
+    private final String _value;
+    public Metadata(MetadataTag tag, String value) {
+        _tag = tag;
+        _value = value;
+    }
+    public MetadataTag tag() {
+        return _tag;
+    }
+    
+    public String value() {
+        return _value;
+    }
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/MetadataTag.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/MetadataTag.java
@@ -1,0 +1,31 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public enum MetadataTag {
+    NAME,
+    SIMPLE_NAME,
+    VERSION,
+    LOCALE,
+    PUBLIC_KEY,
+    PUBLISHER,
+    PUBLICATION_DATE,
+    COPYRIGHT,
+    DESCRIPTION,
+    TRADEMARK,
+    ARTIFACT_ID,
+    LICENSE,
+    DEPENDENCIES,
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ParentFrame.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ParentFrame.java
@@ -1,0 +1,19 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public interface ParentFrame {
+  
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/StringPair.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/StringPair.java
@@ -1,0 +1,17 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public record StringPair(String first, String second) { }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/WorkItem.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/WorkItem.java
@@ -1,0 +1,37 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import io.spicelabs.rodeocomponents.APIS.purls.Purl;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+public interface WorkItem {
+    String identifier();
+    Set<StringPair> connections();
+    WorkItem withConnection(String edgeType, String id);
+    WorkItem merge(WorkItem other);
+    byte[] md5();
+    boolean compareMd5(WorkItem other);
+    boolean isRoot();
+    List<StringPair> referencedFromAliasOrBuildOrContained();
+    WorkItem createOrUpdateInStorage(BackendStorage store, Function<WorkItem, String> context);
+    WorkItem updateBackReferences(BackendStorage store, ParentFrame frame);
+    List<String> containedGitoids();
+    WorkItem enhanceWithPurls(List<Purl> purls);
+    WorkItem enhanceWithMetadata(Optional<String> parent, Set<Metadata> extra, List<String> filenames, List<String> mimeTypes);
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/Purl.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/Purl.java
@@ -1,0 +1,17 @@
+package io.spicelabs.rodeocomponents.APIS.purls;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public interface Purl { }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/PurlAPI.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/PurlAPI.java
@@ -1,0 +1,21 @@
+package io.spicelabs.rodeocomponents.APIS.purls;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import io.spicelabs.rodeocomponents.API;
+
+public interface PurlAPI extends API {
+  PurlFactory newPurlFactory();
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/PurlAPIConstants.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/PurlAPIConstants.java
@@ -1,0 +1,19 @@
+package io.spicelabs.rodeocomponents.APIS.purls;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+class PurlAPIConstants {
+  public static final String NAME = "PurlAPIConstants";
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/PurlFactory.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/purls/PurlFactory.java
@@ -1,0 +1,25 @@
+package io.spicelabs.rodeocomponents.APIS.purls;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public interface PurlFactory {
+    PurlFactory withType(String type);
+    PurlFactory withNamespace(String namespace);
+    PurlFactory withName(String name);
+    PurlFactory withVersion(String name);
+    PurlFactory withSubpath(String subpath);
+    PurlFactory withQualifier(String key, String value);
+    Purl toPurl();
+}


### PR DESCRIPTION
This is my take on the interfacing for defining how artifacts get handled by components.

The main interfacing is through the `AtrifactHandler` interface, but this is a generic interface that won't be used directly.
A component will implement either `FileArtifactHandler` or `InputStreamArtifactHandler` depending on whether they can work with an `InputStream` (no seeking) or a `FileInputStream` (seeking).

The `ArtifactHandler` has 3 main sets of operations:

- identifying MIME types - this is optional, but likely needed.
- answering whether or not it can handle a particular MIME type
- following the operations of the strategies in goat rodeo

I am NOT publishing the types used in goat rodeo because given the choice of reworking those types to make the scala types Java friendly or writing adapters, I think the latter is a better choice.

Purls is a separate API for hooking into the Purl handling types in goat rodeo so components don't need that dependency.

I'm not including the marker type here because the memento pattern will cover that for Java clients.

In terms of how this will be implemented in goat rodeo, there will be a pile of adapter classes and flyweight classes.
