### PR TITLE
Decouple mime identification from artifact handling

### DIFF
--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandler.java
@@ -20,14 +20,12 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ArtifactHandler<T extends InputStream> {
-  Optional<String> identifyMimeType(T stream, String mimeSoFar, String filename);
-  Optional<String> finalMimeAdjustment(T stream, String mimeSoFar, String filename);
-
-  boolean willHandleMime(String mime);
+  String[] supportedMimeTypes();
 
   ArtifactMemento begin(T stream, Artifact artifact, WorkItem item);
   List<Purl> getPurls(ArtifactMemento memento, Artifact artifact, WorkItem item);
   List<Metadata> getMetadata(ArtifactMemento memento, Artifact artifact, WorkItem item);
   void augment(ArtifactMemento memento, Artifact artifact, WorkItem item, ParentFrame parent, BackendStorage storage);
   void postChildProcessing(ArtifactMemento memento, Optional<List<String>> gitoids, BackendStorage storage);
+  void end(ArtifactMemento memento);
 }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeConstants.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeConstants.java
@@ -1,0 +1,20 @@
+package io.spicelabs.rodeocomponents.APIS.mimes;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+public class MimeConstants {
+    public static final String NAME = "MIMEIdentifiers";
+    public static final int UNKNOWN_BYTES_NEEDED = -1;
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeFileInputStreamIdentifier.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeFileInputStreamIdentifier.java
@@ -1,0 +1,19 @@
+package io.spicelabs.rodeocomponents.APIS.mimes;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import java.io.FileInputStream;
+
+public interface MimeFileInputStreamIdentifier extends MimeIdentifer<FileInputStream> { }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeIdentifer.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeIdentifer.java
@@ -1,0 +1,25 @@
+package io.spicelabs.rodeocomponents.APIS.mimes;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import java.io.InputStream;
+import java.util.Optional;
+
+public interface MimeIdentifer<T extends InputStream> {
+    int preferredHeaderLength();
+    boolean canHandleHeader(byte[] header);
+    Optional<String> identifyMimeType(T stream, String mimeSoFar, String filename);
+    Optional<String> finalMimeAdjustment(T stream, String mimeSoFar, String filename);
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeIdentifierRegistrar.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeIdentifierRegistrar.java
@@ -1,0 +1,23 @@
+package io.spicelabs.rodeocomponents.APIS.mimes;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import io.spicelabs.rodeocomponents.API;
+
+public interface MimeIdentifierRegistrar extends API {
+    void register(MimeInputStreamIdentifier mimeIdentifier);
+    void register(MimeFileInputStreamIdentifier mimeIdentifier);
+}
+

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeInputStreamIdentifier.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/mimes/MimeInputStreamIdentifier.java
@@ -1,0 +1,19 @@
+package io.spicelabs.rodeocomponents.APIS.mimes;
+
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+import java.io.InputStream;
+
+public interface MimeInputStreamIdentifier extends MimeIdentifer<InputStream> { }


### PR DESCRIPTION
I inadvertently created a problem in artifact handling.
If any component registers a FileInputStream flavored handler, then every single artifact is required to live as a file because one handler *might* need to look at it. This is clearly a bad idea. Not as bad as Java not having a `canSeek`/`Seek` pair in `InputStream` or a `Seekable` interface, but they never asked me.

I'm addressing this in a couple ways:

First - identifying mime types gets decoupled from artifact handling.
Second - identifying mime types will happen in a multistep process:
1. component gets asked how many header bytes they need
2. component gets handed at least that many bytes to answer whether or not they can handle them
3. component gets handed its flavor of stream to identify a mime type
4. component gets an opportunity to "adjust" the final mime type
Third - ArtifactHandler returns a list of supported mime types

What this enables -
mime identifiers won't get called with a stream unless they're pretty darn sure that they might be able to work on this type. This means that we won't need to create a temp file unless it's absolutely necessary.

Example: .NET assemblies are in PE files and those can be identified by looking at bytes in the header, although the PE files may not be .NET assemblies. So if a file is NOT a PE file, then we can figure that out and NOT create a temp file.  Therefore we will only create a temp file if and only if the file is already a PE file.

Further, we can read header bytes precisely once for all mime identifiers using the max of requested header bytes to minimize stream reading.

Similarly, artifact handlers will return a set of mime types that they can handle and we will summarily ignore the ones that don't match an identified mime type.

In both these cases the creation of a temp file is now as lazy as possible.