### PR TITLE
make some changes to Artifact for easier integration

### DIFF
--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandler.java
@@ -22,10 +22,10 @@ import java.util.Optional;
 public interface ArtifactHandler<T extends InputStream> {
   String[] supportedMimeTypes();
 
-  ArtifactMemento begin(T stream, Artifact artifact, WorkItem item);
-  List<Purl> getPurls(ArtifactMemento memento, Artifact artifact, WorkItem item);
-  List<Metadata> getMetadata(ArtifactMemento memento, Artifact artifact, WorkItem item);
-  void augment(ArtifactMemento memento, Artifact artifact, WorkItem item, ParentFrame parent, BackendStorage storage);
+  ArtifactMemento begin(T stream, RodeoArtifact artifact, WorkItem item);
+  List<Purl> getPurls(ArtifactMemento memento, RodeoArtifact artifact, WorkItem item);
+  List<Metadata> getMetadata(ArtifactMemento memento, RodeoArtifact artifact, WorkItem item);
+  void augment(ArtifactMemento memento, RodeoArtifact artifact, WorkItem item, ParentFrame parent, BackendStorage storage);
   void postChildProcessing(ArtifactMemento memento, Optional<List<String>> gitoids, BackendStorage storage);
   void end(ArtifactMemento memento);
 }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/RodeoArtifact.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/RodeoArtifact.java
@@ -14,8 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-public interface Artifact {
-    String path();
-    long size();
-    String mimeType();
+public interface RodeoArtifact {
+    String getPath();
+    long getSize();
+    String getMimeType();
+    boolean getIsRealFile();
+    String getUuid();
+    String getFilenameWithNoPath();
 }


### PR DESCRIPTION
These changes will make it easier to integrate `ArtifactWrapper` into the components.

The plan it to attach this interface to `ArtifactHandler`

I renamed `Artifact` to `RodeoArtifact` which will make the interface look less a little less weird as an adapter.
I renamed all of the accessors to follow `get<prop>` style which makes them not conflict with the scala names.
I added missing accessors.
