### PR TITLE
renamed methods to not conflict with existing ones in goat rodeo

### DIFF
--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/BackendStorage.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/BackendStorage.java
@@ -19,7 +19,7 @@ import java.util.Set;
 
 public interface BackendStorage {
     void addPurl(Purl purl);
-    Set<String> purls();
-    Set<String> keys();
-    boolean contains(String identifier);
+    Set<String> getPurls();
+    Set<String> getKeys();
+    boolean containsID(String identifier);
 }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/StringPairOptional.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/StringPairOptional.java
@@ -1,0 +1,5 @@
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+import java.util.Optional;
+
+public record StringPairOptional(String first , Optional<String> second) { }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/WorkItem.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/WorkItem.java
@@ -16,22 +16,23 @@ limitations under the License. */
 
 import io.spicelabs.rodeocomponents.APIS.purls.Purl;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
 public interface WorkItem {
-    String identifier();
-    Set<StringPair> connections();
-    WorkItem withConnection(String edgeType, String id);
+    String getIdentifier();
+    Set<StringPair> getConnections();
+    WorkItem withNewConnection(String edgeType, String id);
     WorkItem merge(WorkItem other);
-    byte[] md5();
+    byte[] getMd5();
     boolean compareMd5(WorkItem other);
-    boolean isRoot();
+    boolean isRootWorkItem();
     List<StringPair> referencedFromAliasOrBuildOrContained();
     WorkItem createOrUpdateInStorage(BackendStorage store, Function<WorkItem, String> context);
-    WorkItem updateBackReferences(BackendStorage store, ParentFrame frame);
+    WorkItem updateTheBackReferences(BackendStorage store, ParentFrame frame);
     List<String> containedGitoids();
     WorkItem enhanceWithPurls(List<Purl> purls);
-    WorkItem enhanceWithMetadata(Optional<String> parent, Set<Metadata> extra, List<String> filenames, List<String> mimeTypes);
+    WorkItem enhanceWithMetadata(Optional<String> parent, Map<String, Set<StringPairOptional>> extra, List<String> filenames, List<String> mimeTypes);
 }


### PR DESCRIPTION
for adapting the type `Item` in goat rodeo, there are a number of methods that have the same name but differ in how they're implemented. This PR addresses that and also fixes an incorrect type in enhanceWithMetadata.
It also adds the type StringPairOptional which will pass for StringOrPair