### PR TITLE
Add some needed APIs

### DIFF
--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandlerRegistrar.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/ArtifactHandlerRegistrar.java
@@ -1,5 +1,3 @@
-package io.spicelabs.rodeocomponents.APIS.artifacts;
-
 /* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +11,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
+package io.spicelabs.rodeocomponents.APIS.artifacts;
 
 import io.spicelabs.rodeocomponents.API;
+import java.util.List;
 
 /**
  * This is the main API that is used to process artifacts. The starting point is a {@link RodeoProcessFilter} which
@@ -26,4 +26,14 @@ public interface ArtifactHandlerRegistrar extends API {
      * @param filter A filter for artifacts
      */
     void registerProcessFilter(RodeoProcessFilter filter);
+    /**
+     * Removes an existing process filter by name
+     * @param name the name of the process filter to remove
+     */
+    void removeProcessFilter(String name);
+    /**
+     * Gets a list of the names of all process filters
+     * @return
+     */
+    List<String> getProcessFilterNames();
 }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/EmptyArtifactMemento.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/artifacts/EmptyArtifactMemento.java
@@ -1,0 +1,26 @@
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.rodeocomponents.APIS.artifacts;
+
+/**
+ * An implementation of an ArtifactMemento that contains nothing and does nothing.
+ */
+public class EmptyArtifactMemento implements ArtifactMemento {
+    /**
+     * Gets a singleton implementation of an ArtifactMemento
+     */
+    public static final ArtifactMemento empty = new EmptyArtifactMemento();
+    private EmptyArtifactMemento() { }
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerAPI.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerAPI.java
@@ -15,6 +15,7 @@ limitations under the License. */
 package io.spicelabs.rodeocomponents.APIS.containers;
 
 import io.spicelabs.rodeocomponents.API;
+import java.util.List;
 
 /**
  * Provides an API for registering a ContainerFactory.
@@ -23,7 +24,16 @@ public interface ContainerAPI extends API {
     /**
      * Register a ContainerFactory that will be used for building container handlers
      * @param factory the factory to be registered
+     */
+    void registerContainerFactory(ContainerFactory factory);
+    /**
+     * Given a name of a ContainerFactory, remove it from the list of containerFactories
      * @param name the name of the factory
      */
-    void registerContainerFactory(ContainerFactory factory, String name);
+    void removeContainerFactory(String name);
+    /**
+     * Get the list of all containerFactories
+     * @return a list containing the names of all the container factories
+     */
+    List<String> getContainerFactoryNames();
 }

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerFactory.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerFactory.java
@@ -16,6 +16,7 @@ package io.spicelabs.rodeocomponents.APIS.containers;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.File;
 
 /**
  * Defines how a type that makes ContainerHandler objects will behave. This is used
@@ -49,6 +50,13 @@ public interface ContainerFactory {
      * @return a new ContainerHandler for the container
      */
     ContainerHandler buildHandler(String mimeType, FileInputStream stm);
+    /**
+     * Build a handler for the given mimeType using a File
+     * @param mimeType the mime type of the container
+     * @param file the file for the container
+     * @return a new ContainerHandler for the container
+     */
+    ContainerHandler buildHandler(String mimeType, File file);
     /**
      * Called when the container has been fully processed. This is an opportunity for the handler to clean up
      * any resources.

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerHandler.java
@@ -1,0 +1,41 @@
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.rodeocomponents.APIS.containers;
+
+import java.util.stream.Stream;
+
+/**
+ * An implementation of ContainerHandler that does nothing. Instead of returning null from
+ * the ContainerFactory methods that build factories that are unused, you can return an
+ * EmptyContainerHandler which will do nothing. Its getItems() method returns Stream.empty()
+ * and its onItemProcessed method does nothing.
+ */
+public class EmptyContainerHandler implements ContainerHandler {
+    /**
+     * Gets an singleton instance of the EmptyContainerHandler
+     */
+    public static final ContainerHandler empty = new EmptyContainerHandler();
+
+    private EmptyContainerHandler() { }
+    @Override
+    public Stream<ContainerItem> getItems() {
+        return Stream.empty();
+    }
+
+    @Override
+    public void onItemProcessed(ContainerItem item) {
+    }
+  
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/HandlerResult.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/HandlerResult.java
@@ -29,8 +29,13 @@ public enum HandlerResult {
      */
     WITH_INPUT_STREAM,
     /**
-     * Indicated that the ContainerFactory will handle the candidate container and can
+     * Indicates that the ContainerFactory will handle the candidate container and can
      * work with a FileInputStream.
      */
-    WITH_FILE_INPUT_STREAM
+    WITH_FILE_INPUT_STREAM,
+    /**
+     * Indicates that the ContainerFactory will handle the candidate container and can
+     * work with a File
+     */
+    WITH_FILE,
 }


### PR DESCRIPTION
This PR does several things:

1. It adds APIs for removing and getting the names of process filters and container factories.
2. It adds "empty" implementations of some key types as a nicety and to streamline implementing code
3. It adds the `buildHandler` API which takes a `File` and not an `InputStream` since several existing container handlers do this.

Note that the "empty" types are also singletons.