### PR TITLE
change API for better handling

### DIFF
--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerHandler.java
@@ -14,19 +14,17 @@ limitations under the License. */
 
 package io.spicelabs.rodeocomponents.APIS.containers;
 
-import java.util.stream.Stream;
-
 /**
  * Represents a class that will be called to handle the contents of a container.
  */
 public interface ContainerHandler {
     /**
-     * Get the items within the container. <B>Note</B>: when creating the stream, do not
-     * use a parallel stream as there will be contention over the initial InputStream from
-     * which the items are being extracted.
-     * @return a Stream of items.
+     * Called when a container should produce its items. The items will be provided to the
+     * given receiver.
+     * @param receiver a receiver for the items
+     * @return the final receiver after producing items
      */
-    Stream<ContainerItem> getItems();
+    ContainerReceiver produceItems(ContainerReceiver receiver);
     /**
      * Called when an item has been processed. This gives a ContainerHandler the opportunity
      * to free fresources, if needed.

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerReceiver.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/ContainerReceiver.java
@@ -1,0 +1,34 @@
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.rodeocomponents.APIS.containers;
+
+import java.io.File;
+
+/**
+ * Defines how container items should be reported to goat rodeo. A producer of items should expect to
+ * call this multiple times for each item. Each time receiveItem is called, it will return a ContainerReceiver
+ * that is likely different from the one that is called. Therefore it is important to never assume that the
+ * returned receiver is the same.
+ */
+public interface ContainerReceiver {
+    /**
+     * Provide an item to a receiver which will process it and accumulate it.
+     * @param handler The handler that is providing the item
+     * @param item The item provided
+     * @param tempDirectory a temporary directory (this is provided by ContainerFactory.buildHandler)
+     * @return a (likely) new ContainerReceiver that has received the item
+     */
+    public ContainerReceiver receiveItem(ContainerHandler handler, ContainerItem item, File tempDirectory);
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerHandler.java
@@ -17,8 +17,8 @@ package io.spicelabs.rodeocomponents.APIS.containers;
 /**
  * An implementation of ContainerHandler that does nothing. Instead of returning null from
  * the ContainerFactory methods that build factories that are unused, you can return an
- * EmptyContainerHandler which will do nothing. Its getItems() method returns Stream.empty()
- * and its onItemProcessed method does nothing.
+ * EmptyContainerHandler which will do nothing. Its produceItems() method returns the singleton
+ * instance of the SinkContainerReceiver and its onItemProcessed method does nothing.
  */
 public class EmptyContainerHandler implements ContainerHandler {
     /**
@@ -30,7 +30,7 @@ public class EmptyContainerHandler implements ContainerHandler {
 
     @Override
     public ContainerReceiver produceItems(ContainerReceiver receiver) {
-        return receiver;
+        return SinkContainerReceiver.sink;
     }
 
     @Override

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerHandler.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerHandler.java
@@ -14,8 +14,6 @@ limitations under the License. */
 
 package io.spicelabs.rodeocomponents.APIS.containers;
 
-import java.util.stream.Stream;
-
 /**
  * An implementation of ContainerHandler that does nothing. Instead of returning null from
  * the ContainerFactory methods that build factories that are unused, you can return an
@@ -29,9 +27,10 @@ public class EmptyContainerHandler implements ContainerHandler {
     public static final ContainerHandler empty = new EmptyContainerHandler();
 
     private EmptyContainerHandler() { }
+
     @Override
-    public Stream<ContainerItem> getItems() {
-        return Stream.empty();
+    public ContainerReceiver produceItems(ContainerReceiver receiver) {
+        return receiver;
     }
 
     @Override

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerReceiver.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/EmptyContainerReceiver.java
@@ -1,0 +1,42 @@
+/* Copyright 2026 Stephen Hawley, Spice Labs, Inc. & Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+package io.spicelabs.rodeocomponents.APIS.containers;
+
+import java.io.File;
+
+/**
+ * An empty receiver class that does no actual work. It never accumulates items and it
+ * returns itself. This is meant as a place holder used by EmptyContainerHandler. In practice
+ * it should never be used out of that context.
+ */
+public class EmptyContainerReceiver implements ContainerReceiver {
+    /**
+     * Gets a singleton of the empty container receiver.
+     */
+    public static final ContainerReceiver empty = new EmptyContainerReceiver();
+    private EmptyContainerReceiver() {
+
+    }
+
+    /**
+     * Receives an item, but does nothing with it except mark it processed.
+     */
+    @Override
+    public ContainerReceiver receiveItem(ContainerHandler handler, ContainerItem item, File tempDirectory) {
+        handler.onItemProcessed(item);
+        return this;
+    }
+  
+}

--- a/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/SinkContainerReceiver.java
+++ b/src/main/java/io/spicelabs/rodeocomponents/APIS/containers/SinkContainerReceiver.java
@@ -21,12 +21,12 @@ import java.io.File;
  * returns itself. This is meant as a place holder used by EmptyContainerHandler. In practice
  * it should never be used out of that context.
  */
-public class EmptyContainerReceiver implements ContainerReceiver {
+public class SinkContainerReceiver implements ContainerReceiver {
     /**
-     * Gets a singleton of the empty container receiver.
+     * Gets a singleton of the container receiver sink.
      */
-    public static final ContainerReceiver empty = new EmptyContainerReceiver();
-    private EmptyContainerReceiver() {
+    public static final ContainerReceiver sink = new SinkContainerReceiver();
+    private SinkContainerReceiver() {
 
     }
 


### PR DESCRIPTION
This is a subtle change, but it's important so please read carefully.

In general, I prefer chunky APIs over chatty APIs. This change changes the semantics of `getItems`. The old getItems is a pull model and very chunky. We call it once and we get all the items. It was designed as a Stream so that it should be reasonably efficient. This creates a couple issues:
In the case of the archive fallback, it creates a bunch of slices of the original InputStream and once getItems returns, the original stream is invalid as are the slices. This was patched around by having the implementation of the handler make small local copies of the InputStream slices and returns those in the Stream. This wastes memory and causes a memory tide as most of that memory will get thrown away.

The solution is to instead change the model from "caller pulls a stream of items" to "callee pushes individual items as they have them." This eliminates the need to make a copy of the stream item and has the stream slice uses close to when it was defined. This eliminates the need for extra memory allocation and eliminates the tide.

In addition, this also lets an implementer of the ContainerHandler to work with their items in a fold operation, if their language/containers support them and the ContainerReceiver ends up being the accumulator.

I added an `EmptyContainerReceiver` that does (nearly) nothing. This gets used in the `EmptyContainerHandler` which should only be used for clients that are implementing flavors of buildHandler that will never be called.